### PR TITLE
protocolchecker.py - PROMPT_PATTERN now matches if path contains whit…

### DIFF
--- a/py/sdrl/protocolchecker.py
+++ b/py/sdrl/protocolchecker.py
@@ -85,7 +85,8 @@ class ProtocolExtractor:
     PROMPT_PATTERN = (
         r'(?P<front>^.*?)'
         r'(?P<userhost>[-\+\w]+@[-\+\w]+)'
-        r'\s+(?P<dir>[/~]\S*)'
+        r'\s+(?P<dir>[/~].*?)'
+        r'(?=\s+\d\d:\d\d:\d\d)'
         r'\s+(?P<time>\d\d:\d\d:\d\d)'
         r'\s+(?P<num>\d+)'
         r'(?P<back>.*$)'


### PR DESCRIPTION
## Fix prompt regex for paths with whitespace

Fixes prompt lines not being highlighted when the working directory contains spaces (e.g. `~/Documents/WS 25_26/...`).

### Root Cause

`PROMPT_PATTERN` used `\S*` for the `dir` group, which stops at the first whitespace. This caused the entire regex match to fail for any path containing spaces.

### Change

`protocolchecker.py` — `ProtocolExtractor.PROMPT_PATTERN`:

```python
# before
r'\s+(?P<dir>[/~]\S*)'

# after
r'\s+(?P<dir>[/~].*?)'
r'(?=\s+\d\d:\d\d:\d\d)'
```

The `dir` group now matches lazily up to (but not including) the timestamp, via a lookahead. This allows arbitrary whitespace in the path while keeping all downstream groups (`time`, `num`, `back`) unchanged.

Closes #59 